### PR TITLE
WebM Opus support and adaptive formats regex fix.

### DIFF
--- a/src/main/java/com/github/axet/vget/vhs/YouTubeParser.java
+++ b/src/main/java/com/github/axet/vget/vhs/YouTubeParser.java
@@ -342,6 +342,9 @@ public class YouTubeParser extends VGetParser {
             put(141, new StreamAudio(Container.MP4, Encoding.AAC, AudioQuality.k256));
             put(171, new StreamAudio(Container.WEBM, Encoding.VORBIS, AudioQuality.k128));
             put(172, new StreamAudio(Container.WEBM, Encoding.VORBIS, AudioQuality.k192));
+            put(249, new StreamAudio(Container.WEBM, Encoding.OPUS, AudioQuality.k50));
+            put(250, new StreamAudio(Container.WEBM, Encoding.OPUS, AudioQuality.k70));
+            put(251, new StreamAudio(Container.WEBM, Encoding.OPUS, AudioQuality.k160));
         }
     };
 
@@ -528,7 +531,7 @@ public class YouTubeParser extends VGetParser {
 
         // separate streams
         {
-            Pattern urlencod = Pattern.compile("\"adaptive_fmts\": \"([^\"]*)\"");
+            Pattern urlencod = Pattern.compile("\"adaptive_fmts\":\"([^\"]*)\"");
             Matcher urlencodMatch = urlencod.matcher(html);
             if (urlencodMatch.find()) {
                 String url_encoded_fmt_stream_map;

--- a/src/main/java/com/github/axet/vget/vhs/YoutubeInfo.java
+++ b/src/main/java/com/github/axet/vget/vhs/YoutubeInfo.java
@@ -16,11 +16,11 @@ public class YoutubeInfo extends VideoInfo {
     }
 
     public enum Encoding {
-        H263, H264, VP8, VP9, MP4, MP3, AAC, VORBIS
+        H263, H264, VP8, VP9, MP4, MP3, AAC, VORBIS, OPUS
     }
 
     public enum AudioQuality {
-        k256, k192, k128, k96, k64, k48, k36, k24
+        k256, k192, k128, k96, k64, k48, k36, k24, k50, k70, k160
     }
 
     public static class StreamInfo {


### PR DESCRIPTION
Added support for webm audio with opus inside. Copied values from youtube-dl. fixes #44

Removed space in regex for adaptive formats. fixes #42